### PR TITLE
Add skeleton intrinsics (sse3, sse2, aes).

### DIFF
--- a/rts/minlibc/include/emmintrin.h
+++ b/rts/minlibc/include/emmintrin.h
@@ -1,0 +1,97 @@
+#ifndef __EMMINTRIN_H
+
+#ifndef __SSE2__
+#error "SSE2 not supported, consider using flag -msse2"
+#endif
+
+#include <xmmintrin.h>
+
+// Typedefs borrowed from clang.  Appears legitimate for GCC.
+
+// External interface
+typedef double __m128d __attribute__((__vector_size__(16)));
+typedef long long __m128i __attribute__((__vector_size__(16)));
+
+/* Type defines.  */
+// Internal interface
+typedef double v2df __attribute__ ((__vector_size__ (16)));
+typedef long long v2di __attribute__ ((__vector_size__ (16)));
+typedef short v8hi __attribute__((__vector_size__(16)));
+typedef char v16qi __attribute__((__vector_size__(16)));
+
+extern inline __m128i _mm_andnot_si128(__m128i a, __m128i b)
+{
+    return (__m128i)__builtin_ia32_pandn128((v2di)a,(v2di)b);
+}
+
+extern inline __m128i _mm_and_si128(__m128i a, __m128i b)
+{
+    return (__m128i)__builtin_ia32_pand128((v2di)a,(v2di)b);
+}
+
+extern inline __m128i _mm_or_si128(__m128i a, __m128i b)
+{
+    return (__m128i)__builtin_ia32_por128((v2di)a,(v2di)b);
+}
+
+extern inline __m128i _mm_xor_si128(__m128i a, __m128i b)
+{
+    return (__m128i)__builtin_ia32_pxor128((v2di)a,(v2di)b);
+}
+
+extern inline __m128i _mm_shuffle_epi32(__m128i a, int imm)
+{
+    return (__m128i)__builtin_ia32_pshufd((v4si)a,imm);
+}
+
+extern inline __m128i _mm_load_si128(__m128i const *a)
+{
+    return *a;
+    // What? Missing builtin.  It appears this is handled by gcc code gen magically...
+    // return (__m128i)__builtin_ia32_loaddqa((const char *)p);
+}
+
+extern inline __m128i _mm_loadu_si128(__m128i const *a)
+{
+    return (__m128i)__builtin_ia32_loaddqu((const char *)a);
+}
+
+extern inline void _mm_store_si128(__m128i *p, __m128i b)
+{
+    *p = b;
+    // Again...
+    // __builtin_ia32_storedqa((char *)p, (v16qi)b);
+}
+
+extern inline void _mm_storeu_si128(__m128i *p, __m128i b)
+{
+    __builtin_ia32_storedqu((char *)p, (v16qi)b);
+}
+
+extern inline __m128i _mm_slli_si128(__m128i key, int imm)
+{
+    return (__m128i)__builtin_ia32_pslldqi128((v2di)key , imm*8);
+}
+
+extern inline __m128i _mm_set_epi32(int i3, int i2, int i1, int i0)
+{
+    // Code from clang, assuming it is equally performant for gcc
+    return (__m128i)(v4si){ i0, i1, i2, i3};
+}
+
+extern inline __m128i _mm_setr_epi8(char b15, char b14, char b13, char b12, char b11
+                            ,char b10, char  b9, char  b8, char  b7, char  b6
+                            ,char  b5, char  b4, char  b3, char  b2, char  b1
+                            ,char  b0)
+{
+    // Code from clang, assuming it is equally performant for gcc
+    return (__m128i)(v16qi){ b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15 };
+}
+
+extern inline __m128i _mm_add_epi64(__m128i a, __m128i b)
+{
+    return (__m128i)__builtin_ia32_paddq128((v2di)a, (v2di)b);
+}
+
+
+#endif /* __EMMINTRIN_H */

--- a/rts/minlibc/include/tmmintrin.h
+++ b/rts/minlibc/include/tmmintrin.h
@@ -1,0 +1,14 @@
+
+#ifndef _TMMINTRIN_H
+#define _TMMINTRIN_H
+
+#ifndef __SSSE3__
+#error "Evidently you want SSSE3... consider -mssse3"
+#endif
+
+extern inline __m128i _mm_shuffle_epi8(__m128i a, __m128i b)
+{
+    return (__m128i)__builtin_ia32_pshufb128((v16qi)a, (v16qi)b);
+}
+
+#endif /* TMMINTRIN_H */

--- a/rts/minlibc/include/wmmintrin.h
+++ b/rts/minlibc/include/wmmintrin.h
@@ -1,0 +1,47 @@
+#ifndef _WMMINTRIN_H
+#define _WMMINTRIN_H
+
+#include <emmintrin.h>
+
+#ifdef __AES__
+extern inline __m128i _mm_aesdec_si128(__m128i v, __m128i rkey)
+{
+    return (__m128i)__builtin_ia32_aesdec128((v2di)v, (v2di)rkey);
+}
+
+extern inline __m128i _mm_aesenc_si128(__m128i v, __m128i rkey)
+{
+    return (__m128i)__builtin_ia32_aesenc128((v2di)v, (v2di)rkey);
+}
+
+extern inline __m128i _mm_aesenclast_si128(__m128i v, __m128i rkey)
+{
+    return (__m128i)__builtin_ia32_aesenclast128((v2di)v, (v2di)rkey);
+}
+
+extern inline __m128i _mm_aesdeclast_si128(__m128i v, __m128i rkey)
+{
+    return (__m128i)__builtin_ia32_aesdeclast128((v2di)v, (v2di)rkey);
+}
+
+extern inline __m128i _mm_aeskeygenassist_si128(__m128i ckey, const int rcon)
+{
+    return (__m128i)__builtin_ia32_aeskeygenassist128((v2di)ckey, rcon);
+}
+
+extern inline __m128i _mm_aesimc_si128(__m128i v)
+{
+    return (__m128i)__builtin_ia32_aesimc128((v2di)v);
+}
+#endif /* AES */
+
+
+
+#ifdef __PCLMUL__
+extern inline __m128i _mm_clmulepi64_si128(__m128i v1, __m128i v2, const int imm8)
+{
+    return (__m128i)__builtin_ia32_pclmulqdq128((v2di)v1, (v2di)v2, (char)imm8);
+}
+#endif /* PCLMUL */
+
+#endif

--- a/rts/minlibc/include/xmmintrin.h
+++ b/rts/minlibc/include/xmmintrin.h
@@ -1,0 +1,12 @@
+#ifndef _XMMINTRIN_H
+#define _XMMINTRIN_H
+
+/* User API types */
+typedef float __m128 __attribute__((__vector_size__(16)));
+
+/* Internal interface */
+typedef int v4si __attribute__((__vector_size__(16)));
+typedef float v4sf __attribute__((__vector_size__(16)));
+
+
+#endif /* _XMMINTRIN_H */


### PR DESCRIPTION
The AES and PCLMUL should be complete. SSE3, SSE2 exist but only suffice
for a particular use - users will find seemingly arbitrary functions to
be missing.

A note on testing:

1) Things compiled.
2) We can successfully encrypt and decrypt significant amounts of data.
3) Various factors frustrated testing:
- IVC rendezvous fails without a longer threadDelay.  See issue #27 on HaLVM.
- Using IVC to transmit bytestrings (no AES involved) causes dead lock, frustrating testing.  This is issue #28 on HaLVM.
- Using IVC to encrypt and transmit bytestrings causes one of the domains to segfault (eventually).  HOWEVER, this is unrelated to the intrinsics included in this pull request - we can trigger the same segfault using AES without any AES NI intrinsics, SSE, etc.  I have yet to file a bug report related to this behavior.
